### PR TITLE
Add option to hide pledge identities

### DIFF
--- a/src/config/wishlist/index.js
+++ b/src/config/wishlist/index.js
@@ -4,6 +4,7 @@ export default {
   singleList: yesNo(process.env.SINGLE_LIST || false),
   public: yesNo(process.env.LISTS_PUBLIC || false),
   table: yesNo(process.env.TABLE || true),
+  hidePledgedIdentities: yesNo(process.env.HIDE_PLEDGER_IDENTITIES || false),
   note: {
     markdown: yesNo(process.env.MARKDOWN || false),
   },

--- a/src/languages/cs-cz.ts
+++ b/src/languages/cs-cz.ts
@@ -187,6 +187,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Úspěšně zarezervováno!',
   WISHLIST_PLEDGE: 'Rezervovat',
   WISHLIST_PLEDGED: (pledgedBy) => `Zarezervováno ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Zarezervováno',
   WISHLIST_PRICE: 'Cena',
   WISHLIST_REFRESH_GUARD: 'Neplatné uživatelské jméno',
   WISHLIST_REFRESH_NO_URL: 'Položka nená žádný odkaz.',

--- a/src/languages/da-dk.ts
+++ b/src/languages/da-dk.ts
@@ -184,6 +184,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Gaven er nu reserveret',
   WISHLIST_PLEDGE: 'Reservér',
   WISHLIST_PLEDGED: (pledgedBy) => `Reserveret af ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Reserveret',
   WISHLIST_PLEDGED_GUEST: 'Reserveret af en gæst',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Reserveret gave for ${user}.`,
   WISHLIST_PRICE: 'Pris',

--- a/src/languages/de-de.ts
+++ b/src/languages/de-de.ts
@@ -206,6 +206,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Eintrag erfolgreich reserviert!',
   WISHLIST_PLEDGE: 'Reservieren',
   WISHLIST_PLEDGED: (pledgedBy) => `Reserviert von ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Reserviert',
   WISHLIST_PLEDGED_GUEST: 'Reserviert von einem Gastnutzer',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Eintrag reserviert für ${user}.`,
   WISHLIST_PRICE: 'Preis',

--- a/src/languages/en-us.ts
+++ b/src/languages/en-us.ts
@@ -225,6 +225,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Successfully pledged for item!',
   WISHLIST_PLEDGE: 'Pledge',
   WISHLIST_PLEDGED: (pledgedBy) => `Pledged for by ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Pledged',
   WISHLIST_PLEDGED_GUEST: 'Pledged for by a guest user',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Pledged item for ${user}.`,
   WISHLIST_PRICE: 'Price',

--- a/src/languages/es-es.ts
+++ b/src/languages/es-es.ts
@@ -190,6 +190,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: '¡Producto comprometido!',
   WISHLIST_PLEDGE: 'Comprometer',
   WISHLIST_PLEDGED: (pledgedBy) => `Comprometido por ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Comprometido',
   WISHLIST_PLEDGED_GUEST: 'Comprometido por un usuario invitado',
   WISHLIST_PRICE: 'Precio',
   WISHLIST_REFRESH_GUARD: 'Usuario inválido',

--- a/src/languages/fr-ca.ts
+++ b/src/languages/fr-ca.ts
@@ -192,6 +192,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: "L'article a été promis avec succès",
   WISHLIST_PLEDGE: 'Promettre',
   WISHLIST_PLEDGED: (pledgedBy) => `Promis par: ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Promis',
   WISHLIST_PLEDGED_GUEST: 'Promis par un invité',
   WISHLIST_PRICE: 'Coût',
   WISHLIST_REFRESH_GUARD: 'Utilisateur incorrect',

--- a/src/languages/fr-fr.ts
+++ b/src/languages/fr-fr.ts
@@ -238,6 +238,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: "L'article a été promis avec succès!",
   WISHLIST_PLEDGE: "Je l'offre",
   WISHLIST_PLEDGED: (pledgedBy) => `Promis par ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Promis',
   WISHLIST_PLEDGED_GUEST: 'Promis par un invité',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Article proposé pour ${user}.`,
   WISHLIST_PRICE: 'Prix',

--- a/src/languages/nb-no.ts
+++ b/src/languages/nb-no.ts
@@ -188,6 +188,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Elementet ble reservert!',
   WISHLIST_PLEDGE: 'Reserver',
   WISHLIST_PLEDGED: (pledgedBy) => `Reservert av ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Reservert',
   WISHLIST_PLEDGED_GUEST: 'Reservert av gjestebruker',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Reserverte elementet for ${user}.`,
   WISHLIST_PRICE: 'Pris',

--- a/src/languages/nl-nl.ts
+++ b/src/languages/nl-nl.ts
@@ -192,6 +192,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Item is door je beloofd!',
   WISHLIST_PLEDGE: 'Beloof',
   WISHLIST_PLEDGED: (pledgedBy) => `Beloofd door ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Beloofd',
   WISHLIST_PLEDGED_GUEST: 'Beloofd door een gast',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Item beloofd voor ${user}.`,
   WISHLIST_PRICE: 'Prijs',

--- a/src/languages/pl-pl.ts
+++ b/src/languages/pl-pl.ts
@@ -217,6 +217,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Pomyślnie zadeklarowano prezent!',
   WISHLIST_PLEDGE: 'Zadeklaruj',
   WISHLIST_PLEDGED: (pledgedBy) => `Zadeklarowany przez ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Zadeklarowany',
   WISHLIST_PLEDGED_GUEST: 'Zadeklarowany przez gościa',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) =>
     `Zadeklarowano prezent dla ${user}.`,

--- a/src/languages/pt-pt.ts
+++ b/src/languages/pt-pt.ts
@@ -221,6 +221,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Item reservado com sucesso!',
   WISHLIST_PLEDGE: 'Reservar',
   WISHLIST_PLEDGED: (pledgedBy) => `Reservado por ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Reservado',
   WISHLIST_PLEDGED_GUEST: 'Reservado por convidado',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) => `Item reservado para ${user}.`,
   WISHLIST_PRICE: 'Preço',

--- a/src/languages/ro-ro.ts
+++ b/src/languages/ro-ro.ts
@@ -192,6 +192,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Ați rezervat cadoul!',
   WISHLIST_PLEDGE: 'Rezervați cad',
   WISHLIST_PLEDGED: (pledgedBy) => `Rezervat de către ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Rezervat',
   WISHLIST_PLEDGED_GUEST: 'Rezervat de către un vizitator',
   WISHLIST_PRICE: 'Preț',
   WISHLIST_REFRESH_GUARD: 'Utilizator Invalid',

--- a/src/languages/ru-ru.ts
+++ b/src/languages/ru-ru.ts
@@ -221,6 +221,7 @@ export const strings = {
   WISHLIST_PLEDGE_SUCCESS: 'Предмет успешно зарезервирован!',
   WISHLIST_PLEDGE: 'Зарезервировать',
   WISHLIST_PLEDGED: (pledgedBy) => `Зарезервирован ${pledgedBy}`,
+  WISHLIST_PLEDGED_ANONYMOUS: 'Зарезервирован',
   WISHLIST_PLEDGED_GUEST: 'Зарезервирован незарегистрированным пользователем',
   WISHLIST_PLEDGED_ITEM_FOR_USER: (user) =>
     `Зарезервирован предмет для ${user}.`,

--- a/src/views/wishlist.pug
+++ b/src/views/wishlist.pug
@@ -167,7 +167,9 @@ block content
                         .control.inline
                           input.inline.button(type='submit' value=lang('WISHLIST_UNPLEDGE'))
                   if item.pledgedBy && item.pledgedBy !== req.user._id
-                    if item.pledgedBy === '_CCUNKNOWN'
+                    if global._CC.config.wishlist.hidePledgedIdentities
+                      span.ugc=lang('WISHLIST_PLEDGED_ANONYMOUS')
+                    else if item.pledgedBy === '_CCUNKNOWN'
                       span.ugc=lang('WISHLIST_PLEDGED_GUEST')
                     else
                       span.ugc=lang('WISHLIST_PLEDGED', item.pledgedBy)


### PR DESCRIPTION
## Summary
- add a wishlist configuration flag that can be toggled with the HIDE_PLEDGER_IDENTITIES environment variable
- update the wishlist view so pledged entries show anonymous text when the flag is enabled
- add translation strings across locales for the anonymous pledge message

## Testing
- npm run build *(fails: TypeScript cannot resolve several modules in the container environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e27e51d2308327b71a5412d1c9a7e1